### PR TITLE
Add Private Network Types

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,7 +11,7 @@ project = 'xpx-chain'
 copyright = '2020, ProximaX'
 author = 'ProximaX'
 version = ''
-release = '0.6.6'
+release = '0.6.7'
 
 # GENERAL CONFIGURATION
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,8 @@ universal = 1
 
 [build_sphinx]
 project = 'xpx-chain'
-version = 0.6.6
-release = 0.6.6
+version = 0.6.7
+release = 0.6.7
 warning-is-error = 1
 
 [metadata]

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ MAINTAINER = "Jan"
 MAINTAINER_EMAIL = "wirfeon@gmail.com"
 NAME = "xpx-chain"
 URL = "https://github.com/proximax-storage/python-xpx-chain-sdk"
-VERSION = "0.6.6"
+VERSION = "0.6.7"
 
 DESCRIPTION = "ProximaX Sirius Blockchain Python SDK"
 LONG_DESCRIPTION = "ProximaX Sirius Blockchain Python SDK is a Python library for interacting with the Sirius Blockchain."

--- a/tests/main/models/account_test.py
+++ b/tests/main/models/account_test.py
@@ -235,6 +235,12 @@ class TestAddress(harness.TestCase):
         value = self.type.create_from_public_key(public_key, models.NetworkType.MIJIN_TEST)
         self.assertEqual(value.address, 'SD5DT3CH4BLABL5HIMEKP2TAPUKF4NY3L5HRIR54')
 
+        value = self.type.create_from_public_key(public_key, models.NetworkType.PRIVATE)
+        self.assertEqual(value.address, 'ZD5DT3CH4BLABL5HIMEKP2TAPUKF4NY3L5O47WNH')
+
+        value = self.type.create_from_public_key(public_key, models.NetworkType.PRIVATE_TEST)
+        self.assertEqual(value.address, 'WD5DT3CH4BLABL5HIMEKP2TAPUKF4NY3L5S2PKHO')
+
     def test_plain(self):
         self.assertEqual(self.model.plain(), self.extras['plain'])
 

--- a/tests/main/models/blockchain_test.py
+++ b/tests/main/models/blockchain_test.py
@@ -152,41 +152,51 @@ class TestBlockchainStorageInfo(harness.TestCase):
         models.NetworkType.TEST_NET,
         models.NetworkType.MIJIN,
         models.NetworkType.MIJIN_TEST,
+        models.NetworkType.PRIVATE,
+        models.NetworkType.PRIVATE_TEST
     ],
     'values': [
         0xb8,
         0xa8,
         0x60,
         0x90,
+        0xc8,
+        0xb0,
     ],
     'descriptions': [
         "Main network",
         "Test network",
         "Mijin network",
         "Mijin test network",
+        "Private network",
+        "Private test network",
     ],
     'dto': [
         0xb8,
         0xa8,
         0x60,
         0x90,
+        0xc8,
+        0xb0,
     ],
     'catbuffer': [
         b'\xb8',
         b'\xa8',
         b'\x60',
         b'\x90',
+        b'\xc8',
+        b'\xb0',
     ],
     'custom': [
         {
             'name': 'test_identifier',
             'callback': lambda self, x: x.identifier(),
-            'results': [b'X', B'V', b'M', b'S'],
+            'results': [b'X', B'V', b'M', b'S', b'Z', b'W'],
         },
         {
             'name': 'test_create_from_identifier',
             'callback': lambda self, x: self.type.create_from_identifier(x),
-            'inputs': [b'X', b'V', b'M', b'S'],
+            'inputs': [b'X', b'V', b'M', b'S', b'Z', b'W'],
         },
         {
             'name': 'test_create_from_raw_address',
@@ -196,6 +206,8 @@ class TestBlockchainStorageInfo(harness.TestCase):
                 'VD5DT3CH4BLABL5HIMEKP2TAPUKF4NY3L5HRIR54',
                 'MD5DT3CH4BLABL5HIMEKP2TAPUKF4NY3L5HRIR54',
                 'SD5DT3CH4BLABL5HIMEKP2TAPUKF4NY3L5HRIR54',
+                'ZD5DT3CH4BLABL5HIMEKP2TAPUKF4NY3L5HRIR54',
+                'WD5DT3CH4BLABL5HIMEKP2TAPUKF4NY3L5HRIR54'
             ],
         },
         {

--- a/xpxchain/client/nis.py
+++ b/xpxchain/client/nis.py
@@ -1680,6 +1680,8 @@ NETWORK_TYPE = {
     'mijinTest': models.NetworkType.MIJIN_TEST,
     'public': models.NetworkType.MAIN_NET,
     'publicTest': models.NetworkType.TEST_NET,
+    'private': models.NetworkType.PRIVATE,
+    'privateTest': models.NetworkType.PRIVATE_TEST,
 }
 
 

--- a/xpxchain/models/blockchain/network_type.py
+++ b/xpxchain/models/blockchain/network_type.py
@@ -45,10 +45,12 @@ class NetworkType(util.U8Mixin, util.EnumMixin, enum.IntEnum):
                 description: string
     """
 
-    MAIN_NET   = 0xb8       # noqa: E221
-    TEST_NET   = 0xa8       # noqa: E221
-    MIJIN      = 0x60       # noqa: E221
-    MIJIN_TEST = 0x90       # noqa: E221
+    MAIN_NET     = 0xb8       # noqa: E221
+    TEST_NET     = 0xa8       # noqa: E221
+    MIJIN        = 0x60       # noqa: E221
+    MIJIN_TEST   = 0x90       # noqa: E221
+    PRIVATE      = 0xc8       # noqa: E221
+    PRIVATE_TEST = 0xb0       # noqa: E221
 
     def description(self) -> str:
         return DESCRIPTION[self]
@@ -85,6 +87,8 @@ DESCRIPTION = {
     NetworkType.TEST_NET: "Test network",
     NetworkType.MIJIN: "Mijin network",
     NetworkType.MIJIN_TEST: "Mijin test network",
+    NetworkType.PRIVATE: "Private network",
+    NetworkType.PRIVATE_TEST: "Private test network",
 }
 
 TO_IDENTIFIER = {
@@ -92,6 +96,8 @@ TO_IDENTIFIER = {
     NetworkType.TEST_NET: b"V",
     NetworkType.MIJIN: b"M",
     NetworkType.MIJIN_TEST: b"S",
+    NetworkType.PRIVATE: b"Z",
+    NetworkType.PRIVATE_TEST: b"W",
 }
 
 FROM_IDENTIFIER = {
@@ -99,6 +105,8 @@ FROM_IDENTIFIER = {
     b"V": NetworkType.TEST_NET,
     b"M": NetworkType.MIJIN,
     b"S": NetworkType.MIJIN_TEST,
+    b"Z": NetworkType.PRIVATE,
+    b"W": NetworkType.PRIVATE_TEST,
 }
 
 OptionalNetworkType = typing.Optional[NetworkType]


### PR DESCRIPTION
Adds Private and PrivateTest networks with identifiers sourced from the Golang SDK.

Also adds tests to verify the correct address starting with 'Z' and 'W'.

A version bump to 0.6.7 is also included.